### PR TITLE
Fix Windows line ending issue in Docker entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ COPY . /app
 
 # Your entrypoint
 COPY docker/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+# Fix line endings (Windows CRLF -> Unix LF)
+RUN sed -i 's/\r$//' /entrypoint.sh && chmod +x /entrypoint.sh
 
 EXPOSE 8000 5432
 CMD ["/entrypoint.sh"]


### PR DESCRIPTION
Add sed command to convert CRLF to LF line endings in entrypoint.sh This resolves the 'bash\r': No such file or directory error when running the container on Windows systems.